### PR TITLE
Implement auth tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Everything happens locally or in temp.
 - **Backend:** FastAPI + Python (`cryptography`)
 - **Database:** SQLite (simple, local)
 - **Desktop Tool:** Tkinter GUI for offline decryption
-- **Auth:** Login system in progress
+- **Auth:** JWT-based login system
 - **Frontend:** Coming later (with clean dark-mode UI)
 
 ---
@@ -60,8 +60,8 @@ Everything happens locally or in temp.
 - ✅ Decryption routes fully working
 - ✅ Offline decryptor app (WIP)
 - ✅ Dark mode planned into frontend
-- 🛠️ Login system in progress
-- 🚫 No file uploads or Sign ups for now
+- ✅ Login & sign-up implemented
+- ✅ File uploads for encryption/decryption
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db.session import Base, engine
+
+Base.metadata.create_all(bind=engine)
+
+client = TestClient(app)
+
+
+def test_register_login_encrypt():
+    # 1) register
+    resp = client.post('/api/register', data={'email':'user@example.com','password':'secret'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'license_key' in data
+
+    # 2) login to get token
+    resp = client.post('/api/token', data={'username':'user@example.com','password':'secret'})
+    assert resp.status_code == 200
+    token = resp.json()['access_token']
+    assert token
+
+    # 3) encrypt a small file
+    headers = {'Authorization': f'Bearer {token}'}
+    files = {'file': ('test.txt', b'hello')}
+    resp = client.post('/api/encrypt', headers=headers, files=files, data={'method':'fernet'})
+    assert resp.status_code == 200
+    assert 'attachment' in resp.headers.get('content-disposition', '')
+
+
+def teardown_module(module):
+    try:
+        os.remove('test.db')
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
## Summary
- update README to reflect completed auth, signup, and uploads
- add pytest configuration for test database
- add API test covering register, login, and encrypt endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f92cb5ba88333a33772e39e695ea0