### PR TITLE
Add auth tests and env secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
+Set a `SECRET_KEY` env var to sign JWTs in production:
+
+```bash
+export SECRET_KEY="your-secret-key"
+```
+
 ✍️ Made by
 @nak2002k
 Built from the ground up for people who want encryption that actually respects your files.

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -8,8 +9,9 @@ from sqlalchemy.orm import Session
 from .db.session import SessionLocal
 from .db.crud    import get_user_by_email, get_user_by_license
 
-# SECRET – replace with env var in prod
-SECRET_KEY    = "CHANGE_THIS_SECRET"
+# SECRET used for signing JWTs
+# In production, set the SECRET_KEY environment variable
+SECRET_KEY    = os.getenv("SECRET_KEY", "CHANGE_THIS_SECRET")
 ALGORITHM     = "HS256"
 ACCESS_EXPIRE = timedelta(hours=2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ sqlalchemy
 cryptography
 passlib[bcrypt]
 python-jose[cryptography]
+httpx<0.25
+python-multipart

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+DB_PATH = Path('test_auth.db')
+os.environ['DATABASE_URL'] = f"sqlite:///{DB_PATH}"
+os.environ['SECRET_KEY'] = 'testsecret'
+
+from app.main import app
+from app.db.session import Base, engine
+
+client = TestClient(app)
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+def register_user(email="user@example.com", password="pw"):
+    return client.post('/api/register', data={'email': email, 'password': password})
+
+def login_user(email="user@example.com", password="pw"):
+    return client.post('/api/token', data={'username': email, 'password': password})
+
+def test_register_and_login_flow():
+    r = register_user()
+    assert r.status_code == 200
+    data = r.json()
+    assert data['email'] == 'user@example.com'
+    assert 'license_key' in data
+    r = login_user()
+    assert r.status_code == 200
+    token = r.json()['access_token']
+    assert token
+    r = client.get('/api/dashboard', headers={'Authorization': f'Bearer {token}'})
+    assert r.status_code == 200
+    dash = r.json()
+    assert dash['email'] == 'user@example.com'
+    assert dash['tier'] == 'account'
+
+def test_login_wrong_password():
+    register_user()
+    r = login_user(password='wrong')
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- read JWT secret from SECRET_KEY env var
- document SECRET_KEY in README
- add httpx<0.25 and python-multipart
- add tests for register/login using SQLite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f94541c8c8333af59d0f1b0f20671